### PR TITLE
Adding 'add-manga' command from issue #3

### DIFF
--- a/utilities/job_scheduler.py
+++ b/utilities/job_scheduler.py
@@ -138,10 +138,9 @@ class ScheduledJobs:
 
         for user_id, series_ids in subs.items():  # Unpacking user_id and series_ids
             try:
-                logger.info(f"Processing user_id: {user_id}, series_ids: {series_ids} (type: {type(series_ids)})")
-
                 # Fetch user with user_id
                 user = await self.bot.fetch_user(user_id)
+                logger.info(f"Processing user_id: {user}, series_ids: {series_ids}")
 
                 # Ensure series_ids is either a list or int and handle both cases
                 if isinstance(series_ids, int):


### PR DESCRIPTION
closes #3 

* `add-manga` accepts a mangadex URL and adds it to a staging list in a defined location in `bnu_config.py`
* Updated download management repo (`hillmanation\Mangadex-Batch-Downloader`) to then read this staging list at nightly batch download task add urls to the manga_list.txt download list that don't already exist, and git commit them to the repo to keep the download jobs up to date
* That repo then deletes the staging file from the defined location to reset the lookup task at the next run, if a user has requested a new manga be added